### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,10 @@ on:
       name:
         required: false
 
+permissions:
+  contents: read
+  releases: write
+
 jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Potential fix for [https://github.com/JoshDiDuca/charisma-ai/security/code-scanning/2](https://github.com/JoshDiDuca/charisma-ai/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the workflow. The best way is to add it at the root level of the workflow file (`.github/workflows/main.yml`), so it applies to all jobs unless overridden. Since the workflow performs a release (likely requiring write access to releases and possibly contents), we should set `contents: read` and `releases: write` as a minimal starting point. If the release action also needs to create or update pull requests, we could add `pull-requests: write`, but based on the shown code, `releases: write` should suffice. The change should be made at the top of the file, after the `on:` block and before the `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
