### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 


### PR DESCRIPTION
Potential fix for [https://github.com/JoshDiDuca/charisma-ai/security/code-scanning/1](https://github.com/JoshDiDuca/charisma-ai/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job. The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not write to them. Since the workflow uses `samuelmeuli/action-electron-builder` with `release: true`, it likely needs to create releases and upload assets, which requires `contents: write`. Therefore, the best fix is to add a `permissions` block at the job level (under `release:`) with `contents: write`. This limits the `GITHUB_TOKEN` to only the permissions needed for this job, reducing the risk of privilege escalation.

**What to change:**  
- In `.github/workflows/release.yml`, under the `release:` job (after line 7), add:
  ```yaml
  permissions:
    contents: write
  ```
- No new imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
